### PR TITLE
Portability fixes for few GNU systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.63])
 AC_INIT([nss_securepass], [1.0.0.0])
 AC_CANONICAL_HOST
 case $host_os in
-  linux*)
+  linux* | gnu* | k*bsd*-gnu)
         # OK, let's go on
         AC_MSG_NOTICE(your host_os is $host_os)
         ;;

--- a/minIni.c
+++ b/minIni.c
@@ -72,7 +72,7 @@
   #pragma warning(disable: 4996)	/* for Microsoft Visual C/C++ */
 #endif
 #if !defined strnicmp && !defined PORTABLE_STRNICMP
-  #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
+  #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__ || defined __GLIBC__
     #define strnicmp  strncasecmp
   #endif
 #endif


### PR DESCRIPTION
Small patch series to enable the build also on Hurd and kFreeBSD (current non-Linux ports in the Debian archive).